### PR TITLE
fixed results list not vertically expanding

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ func main() {
 		ui.SageApplicationStart(appWindow)
 
 		appWindow.SetTitle(fmt.Sprintf("%s - %s", APP_NAME, APP_VERSION))
+		appWindow.SetDefaultSize(800, 600)
 		appWindow.SetSizeRequest(800, 600)
 		appWindow.Show()
 

--- a/internal/ui/filebrowser.go
+++ b/internal/ui/filebrowser.go
@@ -62,6 +62,7 @@ func FileBrowserUINew(parent gtk.IWindow, settings *logic.Settings) (*FileBrowse
 		return nil, err
 	}
 	treeView.Connect("row-activated", fbui.treeViewRowActivatedConnection)
+	treeView.SetVExpand(true)
 	treeView.SetModel(listStore)
 	fbui.fileTreeView = treeView
 	fbui.fileListStore = listStore


### PR DESCRIPTION
Enabled `VExpand` property of filebrowser results treeview widget to fix widget not vertically expanding when result list changed.

Solves #7.